### PR TITLE
security: make public phonebook read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 **🌐 Live demo: [phonebook.crosstalkis.com](https://phonebook.crosstalkis.com)** — this
 exact repo, GitOps-deployed by ArgoCD to a self-hosted Kubernetes cluster, served
 through Cloudflare + Traefik (CrowdSec, rate limiting, security headers). It's an
-open demo: add and delete contacts freely — **data resets nightly, don't enter real
-information**. Image provenance is publicly verifiable:
+intentionally **read-only** public demo: production rejects contact mutations in
+the backend itself and displays known sample data. The non-public dev deployment
+retains full CRUD for pipeline and application testing. Image provenance is publicly verifiable:
 `gh attestation verify oci://ghcr.io/alexbeav/devops-phonebook-demo/backend:<tag> --owner Alexbeav`
 
 ![brave_aIIBfqkOBE](https://github.com/user-attachments/assets/789c8001-dfbd-4497-877b-3b3e5ab950e3)
@@ -21,6 +22,7 @@ This project demonstrates a modern, production-style DevOps workflow for a full-
 - **Monitoring:** Prometheus alert rules, discovered by kube-prometheus-stack
 - **Security Scanning:** Trivy (gates images before they are pushed)
 - **Rollback:** One-click GitOps rollback via GitHub Actions
+- **Public-mode safety:** Production is application-enforced read-only; dev remains writable
 
 ## 🚀 Quick Start
 
@@ -100,6 +102,8 @@ npm run dev           # Starts Vite dev server (proxies /api to :5000)
 
 - The frontend calls the backend at `/api`. In production nginx proxies it
   (config comes from the chart's ConfigMap); in dev the Vite proxy handles it.
+- Set `READ_ONLY=true` to make the backend reject all contact mutations. The
+  frontend reads `/api/config` and removes its write controls in that mode.
 
 ---
 
@@ -263,7 +267,11 @@ kubectl get secret myapp-db-credentials -n myapp-prod -o jsonpath='{.data}' | py
 - Monitoring runs on kube-prometheus-stack (see Cluster Prerequisites); the chart ships a backend ServiceMonitor, a postgres exporter (prod), and per-environment `PrometheusRule` alerts.
 - TLS via cert-manager on the standard Ingress (default) or via a `Certificate` on the optional Traefik IngressRoute.
 - PostgreSQL is reachable only from backend pods (and the Prometheus scraper on the exporter port) via NetworkPolicy.
-- The backend container runs as a non-root user; the frontend keeps the stock nginx image (root master process) as an accepted demo tradeoff.
+- Both application containers run as non-root users with read-only root filesystems,
+  all Linux capabilities dropped, and privilege escalation disabled.
+- The public production API permits contact reads only. `POST`, `PUT`, `PATCH`,
+  and `DELETE` receive `405 Method Not Allowed` from the backend. Development
+  remains writable through `backend.readOnly: false`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ kubectl get secret myapp-db-credentials -n myapp-prod -o jsonpath='{.data}' | py
 - The public production API permits contact reads only. `POST`, `PUT`, `PATCH`,
   and `DELETE` receive `405 Method Not Allowed` from the backend. Development
   remains writable through `backend.readOnly: false`.
+- Contact routes also have an application-layer request ceiling. Cloudflare and
+  Traefik provide the per-client edge limits; the backend limit is a final
+  aggregate safety ceiling and does not trust forwarded client-IP headers.
 
 ---
 

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -4,3 +4,4 @@ DB_PASSWORD=secretpassword
 DB_NAME=phonebook
 DB_PORT=5432
 PORT=5000
+READ_ONLY=false

--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -2,9 +2,21 @@ import express from 'express';
 import client from 'prom-client';
 
 // App factory with an injectable pg pool so tests can supply a fake.
-export function createApp(pool) {
+export function createApp(pool, { readOnly = false } = {}) {
     const app = express();
-    app.use(express.json());
+
+    // Production is a public CI/CD showcase, not a public data-entry service.
+    // Enforce read-only mode here so bypassing the UI or edge cannot restore
+    // write access. Reject mutations before parsing their request bodies.
+    app.use('/api/contacts', (req, res, next) => {
+        if (readOnly && !['GET', 'HEAD', 'OPTIONS'].includes(req.method)) {
+            res.set('Allow', 'GET, HEAD, OPTIONS');
+            return res.status(405).json({ error: 'This deployment is read-only' });
+        }
+        next();
+    });
+
+    app.use(express.json({ limit: '8kb', strict: true }));
 
     const register = new client.Registry();
     client.collectDefaultMetrics({ register });
@@ -20,16 +32,34 @@ export function createApp(pool) {
             typeof phone !== 'string' || phone.trim() === '') {
             return res.status(400).json({ error: 'name and phone are required' });
         }
+        if (name.trim().length > 100 || phone.trim().length > 50 ||
+            (req.body.email != null &&
+             (typeof req.body.email !== 'string' || req.body.email.trim().length > 254))) {
+            return res.status(400).json({ error: 'contact fields exceed permitted lengths' });
+        }
         next();
     };
 
+    const validateId = (req, res, next) => {
+        if (!/^[1-9]\d*$/.test(req.params.id)) {
+            return res.status(400).json({ error: 'id must be a positive integer' });
+        }
+        next();
+    };
+
+    app.get('/api/config', (req, res) => {
+        res.json({ readOnly });
+    });
+
     // CRUD Endpoints
     app.get('/api/contacts', asyncHandler(async (req, res) => {
-        const { rows } = await pool.query('SELECT * FROM contacts ORDER BY id');
+        const { rows } = await pool.query(
+            'SELECT id, name, phone, email FROM contacts ORDER BY id LIMIT 500'
+        );
         res.json(rows);
     }));
 
-    app.get('/api/contacts/:id', asyncHandler(async (req, res) => {
+    app.get('/api/contacts/:id', validateId, asyncHandler(async (req, res) => {
         const { id } = req.params;
         const { rows } = await pool.query('SELECT * FROM contacts WHERE id = $1', [id]);
         if (rows.length === 0) return res.status(404).json({ error: 'Not found' });
@@ -37,7 +67,9 @@ export function createApp(pool) {
     }));
 
     app.post('/api/contacts', validateContact, asyncHandler(async (req, res) => {
-        const { name, phone, email } = req.body;
+        const name = req.body.name.trim();
+        const phone = req.body.phone.trim();
+        const email = req.body.email?.trim() || null;
         const { rows } = await pool.query(
             'INSERT INTO contacts (name, phone, email) VALUES ($1, $2, $3) RETURNING *',
             [name, phone, email]
@@ -45,9 +77,11 @@ export function createApp(pool) {
         res.status(201).json(rows[0]);
     }));
 
-    app.put('/api/contacts/:id', validateContact, asyncHandler(async (req, res) => {
+    app.put('/api/contacts/:id', validateId, validateContact, asyncHandler(async (req, res) => {
         const { id } = req.params;
-        const { name, phone, email } = req.body;
+        const name = req.body.name.trim();
+        const phone = req.body.phone.trim();
+        const email = req.body.email?.trim() || null;
         const { rowCount, rows } = await pool.query(
             'UPDATE contacts SET name = $1, phone = $2, email = $3 WHERE id = $4 RETURNING *',
             [name, phone, email, id]
@@ -56,7 +90,7 @@ export function createApp(pool) {
         res.json(rows[0]);
     }));
 
-    app.delete('/api/contacts/:id', asyncHandler(async (req, res) => {
+    app.delete('/api/contacts/:id', validateId, asyncHandler(async (req, res) => {
         const { id } = req.params;
         const { rowCount } = await pool.query('DELETE FROM contacts WHERE id = $1', [id]);
         if (rowCount === 0) return res.status(404).json({ error: 'Not found' });
@@ -90,8 +124,14 @@ export function createApp(pool) {
 
     // eslint-disable-next-line no-unused-vars
     app.use((err, req, res, next) => {
-        console.error(err);
         if (res.headersSent) return next(err);
+        if (err.status === 413) {
+            return res.status(413).json({ error: 'Request body too large' });
+        }
+        if (err.status === 400) {
+            return res.status(400).json({ error: 'Invalid request body' });
+        }
+        console.error(err);
         res.status(500).json({ error: 'Internal server error' });
     });
 

--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -1,8 +1,9 @@
 import express from 'express';
+import { rateLimit } from 'express-rate-limit';
 import client from 'prom-client';
 
 // App factory with an injectable pg pool so tests can supply a fake.
-export function createApp(pool, { readOnly = false } = {}) {
+export function createApp(pool, { readOnly = false, contactRateLimit = 600 } = {}) {
     const app = express();
 
     // Production is a public CI/CD showcase, not a public data-entry service.
@@ -15,6 +16,17 @@ export function createApp(pool, { readOnly = false } = {}) {
         }
         next();
     });
+
+    // This is a backstop at the service hop, so it deliberately keys on the
+    // directly connected Traefik proxy rather than trusting client-supplied
+    // forwarding headers. Per-client enforcement remains at the edge.
+    app.use('/api/contacts', rateLimit({
+        windowMs: 60_000,
+        limit: contactRateLimit,
+        standardHeaders: 'draft-7',
+        legacyHeaders: false,
+        validate: { xForwardedForHeader: false },
+    }));
 
     app.use(express.json({ limit: '8kb', strict: true }));
 

--- a/apps/backend/index.js
+++ b/apps/backend/index.js
@@ -19,6 +19,7 @@ pool.on('error', (err) => {
 });
 
 const port = process.env.PORT || 5000;
-createApp(pool).listen(port, () => {
+const readOnly = process.env.READ_ONLY === 'true';
+createApp(pool, { readOnly }).listen(port, () => {
     console.log(`Backend listening on port ${port}`);
 });

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "dotenv": "^16.4.5",
                 "express": "^4.18.2",
+                "express-rate-limit": "^8.6.2",
                 "pg": "^8.11.3",
                 "prom-client": "^15.1.3"
             },
@@ -413,6 +414,48 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/express-rate-limit": {
+            "version": "8.6.2",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+            "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "ip-address": "^10.2.0"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
+            }
+        },
+        "node_modules/express-rate-limit/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/express-rate-limit/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
         "node_modules/fast-safe-stringify": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -626,6 +669,15 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
+        },
+        "node_modules/ip-address": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+            "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -12,6 +12,7 @@
         "express": "^4.18.2",
         "pg": "^8.11.3",
         "dotenv": "^16.4.5",
+        "express-rate-limit": "^8.6.2",
         "prom-client": "^15.1.3"
     },
     "devDependencies": {

--- a/apps/backend/tests/app.test.js
+++ b/apps/backend/tests/app.test.js
@@ -23,6 +23,14 @@ test('GET /api/contacts returns rows', async () => {
     assert.deepEqual(res.body, [contact]);
 });
 
+test('GET /api/config reports deployment mode', async () => {
+    const pool = fakePool(async () => ({ rows: [], rowCount: 0 }));
+    const res = await request(createApp(pool, { readOnly: true })).get('/api/config');
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body, { readOnly: true });
+    assert.equal(pool.calls.length, 0);
+});
+
 test('GET /api/contacts/:id returns 404 when missing', async () => {
     const pool = fakePool(async () => ({ rows: [], rowCount: 0 }));
     const res = await request(createApp(pool)).get('/api/contacts/99');
@@ -38,11 +46,56 @@ test('POST /api/contacts creates a contact', async () => {
     assert.deepEqual(res.body, contact);
 });
 
+test('read-only mode rejects every contact mutation before touching the DB', async () => {
+    const pool = fakePool(async () => ({ rows: [contact], rowCount: 1 }));
+    const app = createApp(pool, { readOnly: true });
+
+    for (const [method, path] of [
+        ['post', '/api/contacts'],
+        ['put', '/api/contacts/1'],
+        ['patch', '/api/contacts/1'],
+        ['delete', '/api/contacts/1'],
+    ]) {
+        const res = await request(app)[method](path).send(contact);
+        assert.equal(res.status, 405);
+        assert.equal(res.headers.allow, 'GET, HEAD, OPTIONS');
+        assert.deepEqual(res.body, { error: 'This deployment is read-only' });
+    }
+
+    assert.equal(pool.calls.length, 0);
+});
+
 test('POST /api/contacts rejects missing fields with 400 before touching the DB', async () => {
     const pool = fakePool(async () => ({ rows: [], rowCount: 0 }));
     const res = await request(createApp(pool))
         .post('/api/contacts')
         .send({ name: 'No Phone' });
+    assert.equal(res.status, 400);
+    assert.equal(pool.calls.length, 0);
+});
+
+test('POST /api/contacts rejects oversized fields before touching the DB', async () => {
+    const pool = fakePool(async () => ({ rows: [], rowCount: 0 }));
+    const res = await request(createApp(pool))
+        .post('/api/contacts')
+        .send({ name: 'x'.repeat(101), phone: '555-0100' });
+    assert.equal(res.status, 400);
+    assert.equal(pool.calls.length, 0);
+});
+
+test('POST /api/contacts rejects bodies larger than 8 KiB', async () => {
+    const pool = fakePool(async () => ({ rows: [], rowCount: 0 }));
+    const res = await request(createApp(pool))
+        .post('/api/contacts')
+        .send({ name: 'Ada', phone: '555-0100', padding: 'x'.repeat(9 * 1024) });
+    assert.equal(res.status, 413);
+    assert.deepEqual(res.body, { error: 'Request body too large' });
+    assert.equal(pool.calls.length, 0);
+});
+
+test('contact routes reject malformed IDs before touching the DB', async () => {
+    const pool = fakePool(async () => ({ rows: [], rowCount: 0 }));
+    const res = await request(createApp(pool)).get('/api/contacts/not-a-number');
     assert.equal(res.status, 400);
     assert.equal(pool.calls.length, 0);
 });

--- a/apps/backend/tests/app.test.js
+++ b/apps/backend/tests/app.test.js
@@ -31,6 +31,15 @@ test('GET /api/config reports deployment mode', async () => {
     assert.equal(pool.calls.length, 0);
 });
 
+test('contact API has an application-layer request ceiling', async () => {
+    const pool = fakePool(async () => ({ rows: [contact], rowCount: 1 }));
+    const app = createApp(pool, { contactRateLimit: 2 });
+    assert.equal((await request(app).get('/api/contacts')).status, 200);
+    assert.equal((await request(app).get('/api/contacts')).status, 200);
+    assert.equal((await request(app).get('/api/contacts')).status, 429);
+    assert.equal(pool.calls.length, 2);
+});
+
 test('GET /api/contacts/:id returns 404 when missing', async () => {
     const pool = fakePool(async () => ({ rows: [], rowCount: 0 }));
     const res = await request(createApp(pool)).get('/api/contacts/99');

--- a/apps/frontend/src/App.jsx
+++ b/apps/frontend/src/App.jsx
@@ -3,15 +3,27 @@ import React, { useEffect, useState } from "react";
 export default function App() {
     const [contacts, setContacts] = useState([]);
     const [loading, setLoading] = useState(true);
+    // Fail closed: write controls appear only after the backend explicitly
+    // reports that this deployment is writable.
+    const [readOnly, setReadOnly] = useState(true);
     const [form, setForm] = useState({ name: "", phone: "", email: "" });
     const [error, setError] = useState("");
 
     // Fetch contacts
     useEffect(() => {
-        fetch("/api/contacts")
-            .then((res) => res.json())
-            .then((data) => {
-                setContacts(data);
+        Promise.all([
+            fetch("/api/contacts").then((res) => {
+                if (!res.ok) throw new Error("Contact fetch failed");
+                return res.json();
+            }),
+            fetch("/api/config").then((res) => {
+                if (!res.ok) throw new Error("Config fetch failed");
+                return res.json();
+            }),
+        ])
+            .then(([contactsData, config]) => {
+                setContacts(contactsData);
+                setReadOnly(config.readOnly !== false);
                 setLoading(false);
             })
             .catch(() => {
@@ -64,7 +76,7 @@ export default function App() {
         }}>
             <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem", color: "#0099ff" }}>🔵 Phonebook Contacts</h1>
             <div className="label" style={{ color: "#888", fontSize: "0.9rem", marginBottom: "2rem" }}>
-                Served by Nginx inside Docker & Kubernetes
+                {readOnly ? "Public production demo — read-only" : "Development demo — writes enabled"}
             </div>
             <div style={{ display: "flex", gap: 48, width: "100%", maxWidth: 900 }}>
                 <div style={{ flex: 1, minWidth: 300 }}>
@@ -79,15 +91,17 @@ export default function App() {
                                     <span>
                                         <b style={{ color: "#0099ff" }}>{c.name}</b> — {c.phone} {c.email && <span style={{ color: "#888" }}>({c.email})</span>}
                                     </span>
-                                    <button style={{ marginLeft: 16, background: "#222", color: "#ff3366", border: "none", borderRadius: 4, padding: "4px 12px", cursor: "pointer" }} onClick={() => handleDelete(c.id)}>
-                                        Delete
-                                    </button>
+                                    {!readOnly && (
+                                        <button style={{ marginLeft: 16, background: "#222", color: "#ff3366", border: "none", borderRadius: 4, padding: "4px 12px", cursor: "pointer" }} onClick={() => handleDelete(c.id)}>
+                                            Delete
+                                        </button>
+                                    )}
                                 </li>
                             ))}
                         </ul>
                     )}
                 </div>
-                <div style={{ flex: 1, minWidth: 300 }}>
+                {!readOnly && <div style={{ flex: 1, minWidth: 300 }}>
                     <h2 style={{ color: "#0099ff", borderBottom: "1px solid #222", paddingBottom: 8 }}>Add Contact</h2>
                     <form onSubmit={handleAdd} style={{ display: "flex", flexDirection: "column", gap: 12, background: "#181818", padding: 24, borderRadius: 8, maxWidth: 350 }}>
                         <input
@@ -112,7 +126,7 @@ export default function App() {
                         />
                         <button type="submit" style={{ background: "#0099ff", color: "#0f0f0f", border: "none", borderRadius: 4, padding: "8px 0", fontWeight: "bold", cursor: "pointer" }}>Add</button>
                     </form>
-                </div>
+                </div>}
             </div>
         </div>
     );

--- a/apps/frontend/src/App.test.jsx
+++ b/apps/frontend/src/App.test.jsx
@@ -4,8 +4,11 @@ import App from "./App.jsx";
 
 describe("App", () => {
     beforeEach(() => {
-        vi.stubGlobal("fetch", vi.fn(() =>
-            Promise.resolve({
+        vi.stubGlobal("fetch", vi.fn((url) =>
+            Promise.resolve(url === "/api/config" ? {
+                ok: true,
+                json: () => Promise.resolve({ readOnly: true }),
+            } : {
                 ok: true,
                 json: () => Promise.resolve([
                     { id: 1, name: "Ada", phone: "555-0100", email: "ada@example.com" },
@@ -19,5 +22,26 @@ describe("App", () => {
         expect(screen.getByText(/Phonebook Contacts/)).toBeDefined();
         expect(await screen.findByText("Ada")).toBeDefined();
         expect(fetch).toHaveBeenCalledWith("/api/contacts");
+        expect(fetch).toHaveBeenCalledWith("/api/config");
+        expect(await screen.findByText(/read-only/)).toBeDefined();
+        expect(screen.queryByText("Add Contact")).toBeNull();
+        expect(screen.queryByText("Delete")).toBeNull();
+    });
+
+    it("shows write controls only when the backend explicitly enables them", async () => {
+        fetch.mockImplementation((url) => Promise.resolve(url === "/api/config" ? {
+            ok: true,
+            json: () => Promise.resolve({ readOnly: false }),
+        } : {
+            ok: true,
+            json: () => Promise.resolve([
+                { id: 1, name: "Ada", phone: "555-0100", email: "ada@example.com" },
+            ]),
+        }));
+
+        render(<App />);
+        expect(await screen.findByText("Add Contact")).toBeDefined();
+        expect(screen.getByText("Delete")).toBeDefined();
+        expect(screen.getByText(/writes enabled/)).toBeDefined();
     });
 });

--- a/charts/myapp/templates/backend-deployment.yaml
+++ b/charts/myapp/templates/backend-deployment.yaml
@@ -133,6 +133,8 @@ spec:
               value: {{ .Values.postgresql.auth.database | quote }}
             - name: DB_PORT
               value: "5432"
+            - name: READ_ONLY
+              value: {{ .Values.backend.readOnly | quote }}
           # Startup tolerance covers the migration initContainers having just
           # finished; readiness is DB-aware, liveness is process-only.
           startupProbe:

--- a/charts/myapp/templates/demo-reset-cronjob.yaml
+++ b/charts/myapp/templates/demo-reset-cronjob.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.demoReset.enabled }}
-# Public demo hygiene: wipes user-submitted contacts on a schedule so the
-# exposed instance stays fresh and junk never accumulates.
+# Public demo hygiene: restores known sample data on a schedule.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -42,8 +41,15 @@ spec:
                     - ALL
               command:
                 - psql
+                - -v
+                - ON_ERROR_STOP=1
                 - -c
-                - TRUNCATE contacts RESTART IDENTITY
+                - |
+                  TRUNCATE contacts RESTART IDENTITY;
+                  INSERT INTO contacts (name, phone, email) VALUES
+                    ('Ada Lovelace', '+1 555-0101', 'ada@example.com'),
+                    ('Grace Hopper', '+1 555-0102', 'grace@example.com'),
+                    ('Margaret Hamilton', '+1 555-0103', 'margaret@example.com');
               env:
                 - name: PGHOST
                   value: {{ .Values.postgresql.fullnameOverride | quote }}

--- a/charts/myapp/values-dev.yaml
+++ b/charts/myapp/values-dev.yaml
@@ -26,6 +26,7 @@ monitoring:
 backend:
   image: ghcr.io/alexbeav/devops-phonebook-demo/backend
   tag: "98a8457"
+  readOnly: false
   replicaCount: 1
   service:
     type: ClusterIP

--- a/charts/myapp/values-prod.yaml
+++ b/charts/myapp/values-prod.yaml
@@ -14,7 +14,8 @@ ingress:
       namespace: traefik
     - name: security-headers
       namespace: traefik
-# Public demo instance: nightly contacts wipe (04:00 cluster time)
+# Public demo instance: application-enforced read-only mode plus a nightly
+# reset to known harmless sample data (04:00 cluster time).
 demoReset:
   enabled: true
   schedule: "0 4 * * *"
@@ -24,6 +25,7 @@ monitoring:
 backend:
   image: ghcr.io/alexbeav/devops-phonebook-demo/backend
   tag: "98a8457"
+  readOnly: true
   replicaCount: 3
   service:
     type: ClusterIP

--- a/charts/myapp/values.yaml
+++ b/charts/myapp/values.yaml
@@ -38,6 +38,9 @@ backend:
   image: ghcr.io/alexbeav/devops-phonebook-demo/backend
   # CI pushes a moving 'latest' alongside immutable SHA tags; the env overlays pin SHAs.
   tag: "latest"
+  # The application rejects POST/PUT/PATCH/DELETE when true. Keep local/dev
+  # writable; production overrides this to true.
+  readOnly: false
   replicaCount: 1
   service:
     type: ClusterIP


### PR DESCRIPTION
## Security outcome
- makes production contact access application-enforced read-only
- keeps the non-public dev deployment writable
- hides write controls unless the backend explicitly enables them
- caps JSON bodies at 8 KiB, validates field lengths and IDs, and limits list responses
- reseeds production with known sample contacts
- updates the public README to describe the actual exposure model

## Verification
- backend: 14 tests passed; production dependency audit: 0 vulnerabilities
- frontend: 2 tests passed; production build passed; production dependency audit: 0 vulnerabilities
- Helm lint passed for dev and prod
- rendered dev/prod manifests passed kubectl client validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the public phonebook read-only and adds an application-layer request ceiling on contact APIs. Previously the demo allowed writes and had no backend throttling; now mutations return 405 and `/api/contacts` is rate limited to blunt scraping/abuse, while dev remains writable.

- Backend: adds `readOnly` mode via `READ_ONLY` env; rejects `POST`/`PUT`/`PATCH`/`DELETE` on `/api/contacts` before body parsing and sets `Allow`; exposes `/api/config`; applies `express-rate-limit` on `/api/contacts` (default 600/min, keys on the direct hop and ignores forwarded client IPs); limits list responses to 500; enforces 8 KiB JSON bodies; trims inputs; validates field lengths and positive integer IDs; returns friendly 400/413 errors.
- Frontend: fails closed until `/api/config` reports `readOnly: false`; hides Add/Delete and shows a mode banner; tests cover both modes.
- Helm/ops: passes `READ_ONLY` to the Deployment; sets `backend.readOnly: true` in prod and `false` in dev; demo reset job reseeds known sample contacts nightly; README documents public read-only mode and container hardening.

**Rollout**
- No DB migrations. Deploy charts so prod sets `backend.readOnly: true`; dev/local keep `false`.
- Post-deploy: confirm `/api/config` mode, UI controls, 405 + `Allow` for mutations, and 429 from `/api/contacts` under configured limits.
- Ensure edge/CDN/proxies do not override 405 or change rate-limit behavior; we do not trust forwarded client IP headers.

<sup>Written for commit 9438eb4cbb2cc1224b7e95d2662b6f6faeae0954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Alexbeav/devops-phonebook-demo/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

