### PR TITLE
security: give production backend read-only DB role

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -51,6 +51,20 @@ jobs:
           ./kyverno apply policies/require-resources.yaml policies/require-probes.yaml policies/disallow-latest-tag.yaml \
             --resource /tmp/prod-render.yaml
 
+      - name: Verify production database privilege split
+        run: |
+          set -euo pipefail
+
+          runtime_user=$(yq e 'select(.kind == "Deployment" and .metadata.name == "myapp-backend") | .spec.template.spec.containers[] | select(.name == "backend") | .env[] | select(.name == "DB_USER") | .value' /tmp/prod-render.yaml)
+          runtime_secret=$(yq e 'select(.kind == "Deployment" and .metadata.name == "myapp-backend") | .spec.template.spec.containers[] | select(.name == "backend") | .env[] | select(.name == "DB_PASSWORD") | .valueFrom.secretKeyRef.name' /tmp/prod-render.yaml)
+          migration_user=$(yq e 'select(.kind == "Deployment" and .metadata.name == "myapp-backend") | .spec.template.spec.initContainers[] | select(.name == "run-migrations") | .env[] | select(.name == "DB_USER") | .value' /tmp/prod-render.yaml)
+          migration_secret=$(yq e 'select(.kind == "Deployment" and .metadata.name == "myapp-backend") | .spec.template.spec.initContainers[] | select(.name == "run-migrations") | .env[] | select(.name == "DB_PASSWORD") | .valueFrom.secretKeyRef.name' /tmp/prod-render.yaml)
+
+          test "$runtime_user" = "myappreader"
+          test "$runtime_secret" = "myapp-db-reader-credentials"
+          test "$migration_user" = "myappuser"
+          test "$migration_secret" = "myapp-db-credentials"
+
   build-and-scan:
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -171,31 +171,23 @@ NetworkPolicy only admits scrapes from Prometheus pods in `monitoring`.
 ---
 
 
-## 🔐 Managing Database Credentials with SealedSecrets
+## 🔐 Managing Database Credentials
 
-The production Helm values (`values-prod.yaml`) reference a Kubernetes Secret via `existingSecret: myapp-db-credentials` instead of storing passwords in Git. [Bitnami SealedSecrets](https://github.com/bitnami-labs/sealed-secrets) lets you encrypt secrets with your cluster's public key so the encrypted form is safe to commit. The SealedSecrets controller in your cluster decrypts them automatically.
+Production uses two Kubernetes Secrets. `myapp-db-credentials` contains the
+database owner and writer credentials. `myapp-db-reader-credentials` contains
+the SELECT-only credential used by the public backend.
 
-> **Dev environment:** `values-dev.yaml` keeps an inline password for convenience — the Bitnami PostgreSQL subchart auto-creates the Secret. For production, always use SealedSecrets.
+Do not store either plaintext secret in Git. Use your cluster's secret manager,
+such as Vault Secrets Operator, External Secrets Operator, or SealedSecrets.
+The live homelab currently bootstraps these two Secrets out of band.
 
-### 1. Install the SealedSecrets controller
+> **Dev environment:** `values-dev.yaml` keeps an inline password for convenience.
+> The Bitnami PostgreSQL subchart creates the development Secret.
 
-```bash
-helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets
-helm install sealed-secrets sealed-secrets/sealed-secrets \
-  --namespace sealed-secrets --create-namespace
-```
+### Required production keys
 
-### 2. Install the kubeseal CLI
-
-```bash
-curl -OL "https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.30.0/kubeseal-0.30.0-linux-amd64.tar.gz"
-tar -xvzf kubeseal-0.30.0-linux-amd64.tar.gz kubeseal
-sudo install -m 755 kubeseal /usr/local/bin/kubeseal
-```
-
-### 3. Create a plaintext Secret manifest (local only — never commit this)
-
-The Bitnami PostgreSQL chart expects keys `postgres-password` (superuser) and `password` (application user). The backend deployment also reads `password` from this same Secret.
+The Bitnami PostgreSQL chart requires `postgres-password` and `password` in
+`myapp-db-credentials`. Migration and reset jobs use its `password` key.
 
 Create a file called `tmp-prod-secret.yaml` (do **not** commit it):
 
@@ -211,54 +203,32 @@ stringData:
   password: "<your-app-user-password>"
 ```
 
-### 4. Seal the Secret
+The public backend Secret requires `username` and `password`:
 
-```bash
-kubeseal \
-  --controller-name=sealed-secrets \
-  --controller-namespace=sealed-secrets \
-  --format yaml \
-  < tmp-prod-secret.yaml \
-  > manifests/sealedsecret-db-prod.yaml
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: myapp-db-reader-credentials
+  namespace: myapp-prod
+type: Opaque
+stringData:
+  username: myappreader
+  password: "<reader-password>"
 ```
 
-Delete the plaintext file immediately:
-```bash
-rm tmp-prod-secret.yaml
-```
+Provision `myappreader` in PostgreSQL with only `CONNECT`, schema `USAGE`, and
+`SELECT` on `public.contacts`. Set `default_transaction_read_only=on` as a
+second control. Remove `CREATEDB`, `CREATEROLE`, superuser, replication, and
+inherit privileges from this role.
 
-Repeat for dev if desired (change `namespace` to `myapp-dev`).
-
-### 5. Commit the encrypted SealedSecret to Git
-
-The sealed file is safe to commit — it can only be decrypted by your cluster's controller.
+### Verify
 
 ```bash
-git add manifests/sealedsecret-db-prod.yaml
-git commit -m "Add sealed database credentials for production"
-git push
-```
-
-### 6. Apply to the cluster (bootstrap)
-
-Before the first ArgoCD sync, create the namespaces and apply the sealed secrets:
-
-```bash
-kubectl create namespace myapp-prod --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -f manifests/sealedsecret-db-prod.yaml
-```
-
-The SealedSecrets controller will decrypt it into a regular Secret named `myapp-db-credentials` in the `myapp-prod` namespace. ArgoCD will then be able to deploy the Helm chart, which references this Secret.
-
-### 7. Verify
-
-```bash
-# Check the SealedSecret was processed
-kubectl get sealedsecret myapp-db-credentials -n myapp-prod
-
-# Check the decrypted Secret exists with the expected keys
-kubectl get secret myapp-db-credentials -n myapp-prod -o jsonpath='{.data}' | python3 -c "import sys,json; print(list(json.load(sys.stdin).keys()))"
-# Should output: ['password', 'postgres-password']
+kubectl get secret myapp-db-credentials myapp-db-reader-credentials -n myapp-prod
+kubectl -n myapp-prod get deployment myapp-backend \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="DB_USER")].value}'
+# Expected: myappreader
 ```
 
 ---

--- a/charts/myapp/templates/backend-deployment.yaml
+++ b/charts/myapp/templates/backend-deployment.yaml
@@ -123,12 +123,12 @@ spec:
             - name: DB_HOST
               value: {{ .Values.postgresql.fullnameOverride | quote }}
             - name: DB_USER
-              value: {{ .Values.postgresql.auth.username | quote }}
+              value: {{ .Values.backend.databaseUser | default .Values.postgresql.auth.username | quote }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.postgresql.auth.existingSecret | default .Values.postgresql.fullnameOverride }}
-                  key: password
+                  name: {{ .Values.backend.databaseSecret | default (.Values.postgresql.auth.existingSecret | default .Values.postgresql.fullnameOverride) }}
+                  key: {{ .Values.backend.databasePasswordKey | default "password" }}
             - name: DB_NAME
               value: {{ .Values.postgresql.auth.database | quote }}
             - name: DB_PORT

--- a/charts/myapp/values-prod.yaml
+++ b/charts/myapp/values-prod.yaml
@@ -26,6 +26,11 @@ backend:
   image: ghcr.io/alexbeav/devops-phonebook-demo/backend
   tag: "8731336"
   readOnly: true
+  # The public backend receives SELECT-only database credentials. Migrations
+  # and the reset job continue to use the separate myappuser writer account.
+  databaseUser: myappreader
+  databaseSecret: myapp-db-reader-credentials
+  databasePasswordKey: password
   replicaCount: 3
   service:
     type: ClusterIP

--- a/charts/myapp/values.yaml
+++ b/charts/myapp/values.yaml
@@ -41,6 +41,11 @@ backend:
   # The application rejects POST/PUT/PATCH/DELETE when true. Keep local/dev
   # writable; production overrides this to true.
   readOnly: false
+  # Runtime database identity. Empty values fall back to the PostgreSQL app
+  # user and secret, which keeps local and development installs simple.
+  databaseUser: ""
+  databaseSecret: ""
+  databasePasswordKey: password
   replicaCount: 1
   service:
     type: ClusterIP


### PR DESCRIPTION
## Security outcome
- gives the public production backend a SELECT-only `myappreader` login
- keeps the writer login only in migration and reset jobs
- preserves the existing writable development deployment
- adds a CI assertion for the rendered credential boundary
- corrects the README secret-management description to match the live cluster

## Live prerequisite already verified
- `myappreader` has `default_transaction_read_only=on`
- SELECT succeeded from an isolated probe pod
- INSERT, UPDATE, and DELETE failed
- `myappuser` no longer has CREATEDB
- the reader Secret exists before rollout

## Local verification
- Helm lint passed for dev and prod
- rendered dev and prod manifests passed Kubernetes client validation
- production render: runtime=`myappreader`; migration=`myappuser`
- development render remains `myappuser`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route the production backend through a read‑only database role to prevent writes from the public service. Previously the backend used the writer role; now runtime uses `myappreader` (SELECT‑only) while migrations and reset jobs continue to use `myappuser`. Development stays writable.

- Adds Helm values `backend.databaseUser`, `backend.databaseSecret`, and `backend.databasePasswordKey`; defaults preserve dev behavior. Production sets `databaseUser: myappreader` and `databaseSecret: myapp-db-reader-credentials`.
- Updates `backend` deployment to read DB env vars from the new values, falling back to existing PostgreSQL chart values when unset.
- Adds CI check that the rendered prod manifests use the reader secret for the runtime container and the writer secret for the migration initContainer.
- Updates README to document the two production Secrets and required keys.

**Rollout and verification**
- Create the Secret `myapp-db-reader-credentials` in `myapp-prod` with keys: `username: myappreader`, `password: <reader-password>`.
- Ensure PostgreSQL role `myappreader` exists with only CONNECT, schema USAGE, and SELECT on required tables, and set `default_transaction_read_only=on`. Remove CREATEDB/CREATEROLE/superuser/replication/INHERIT from this role.
- Keep `myapp-db-credentials` for migrations/reset; no change needed for dev.
- After deploy, verify `myapp-backend` uses `DB_USER=myappreader` and that writes are blocked while migrations still succeed.

<sup>Written for commit 4cb93cf1743678916e0c57cc6339222cb857f260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Alexbeav/devops-phonebook-demo/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

