### PR TITLE
security: stage Phonebook tunnel-only edge route

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -65,6 +65,17 @@ jobs:
           test "$migration_user" = "myappuser"
           test "$migration_secret" = "myapp-db-credentials"
 
+      - name: Verify production edge isolation settings
+        run: |
+          set -euo pipefail
+
+          entrypoints=$(yq e 'select(.kind == "IngressRoute") | .spec.entryPoints[]' /tmp/prod-render.yaml | paste -sd, -)
+          middlewares=$(yq e 'select(.kind == "IngressRoute") | .spec.routes[].middlewares[].name' /tmp/prod-render.yaml | sort -u | paste -sd, -)
+
+          test "$entrypoints" = "websecure,websecure-cf"
+          echo "$middlewares" | grep -Eq '(^|,)body-limit-phonebook(,|$)'
+          echo "$middlewares" | grep -Eq '(^|,)rate-limit-phonebook(,|$)'
+
   build-and-scan:
     runs-on: ubuntu-latest
     permissions:

--- a/charts/myapp/templates/ingressroute.yaml
+++ b/charts/myapp/templates/ingressroute.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ include "myapp.fullname" . }}-ingressroute
 spec:
   entryPoints:
-    - web
-    - websecure
+    {{- range .Values.ingress.entryPoints }}
+    - {{ . }}
+    {{- end }}
   routes:
     # Backend keeps its /api prefix - no stripPrefix middleware. The Express
     # routes are registered as /api/..., so stripping the prefix would 404.

--- a/charts/myapp/values-dev.yaml
+++ b/charts/myapp/values-dev.yaml
@@ -11,6 +11,8 @@ ingress:
   # Ingress support); TLS comes from the cert-manager Certificate the chart
   # creates (letsencrypt-prod, DNS-01).
   useIngressRoute: true
+  entryPoints:
+    - websecure
   tls:
     enabled: true
   middlewares:

--- a/charts/myapp/values-prod.yaml
+++ b/charts/myapp/values-prod.yaml
@@ -5,12 +5,19 @@ ingress:
   # Ingress support); TLS comes from the cert-manager Certificate the chart
   # creates (letsencrypt-prod, DNS-01).
   useIngressRoute: true
+  # Keep the current path during the staged migration. Cloudflare Tunnel will
+  # move to websecure-cf only after this route is healthy on both entrypoints.
+  entryPoints:
+    - websecure
+    - websecure-cf
   tls:
     enabled: true
   middlewares:
     - name: crowdsec-bouncer
       namespace: traefik
-    - name: rate-limit
+    - name: rate-limit-phonebook
+      namespace: traefik
+    - name: body-limit-phonebook
       namespace: traefik
     - name: security-headers
       namespace: traefik

--- a/charts/myapp/values.yaml
+++ b/charts/myapp/values.yaml
@@ -11,6 +11,9 @@ runtimeClassName: ""
 ingress:
   host: myapp.local
   useIngressRoute: false # true switches to Traefik IngressRoute (also served by cert-manager)
+  entryPoints:
+    - web
+    - websecure
   tls:
     enabled: false # requires cert-manager + a 'letsencrypt-prod' ClusterIssuer (see README)
   # Optional Traefik middlewares applied to both routes (IngressRoute mode),


### PR DESCRIPTION
Adds configurable Traefik entrypoints, makes dev HTTPS-only, and stages production Phonebook on both the existing and Cloudflare-only entrypoints. Replaces the generic rate limit with Phonebook-specific rate and 8 KiB request-body middleware. Cloudflare Tunnel traffic is not switched by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stages a Cloudflare Tunnel–only edge route for Phonebook and makes Traefik entry points configurable. Previously the IngressRoute hardcoded `web`/`websecure` with a generic rate limit; now `ingress.entryPoints` sets entry points per env (dev = `websecure` only; prod = `websecure` + `websecure-cf`) and prod uses `rate-limit-phonebook` plus an 8 KiB `body-limit-phonebook`; Tunnel traffic is not switched.

**Review and rollout**
- Helm: template iterates `ingress.entryPoints`; defaults stay `web`,`websecure`; dev overrides to `websecure`; prod to `websecure`,`websecure-cf`.
- CI: asserts prod render has both entry points and includes `rate-limit-phonebook` and `body-limit-phonebook`.
- Migration: ensure `traefik` middlewares `rate-limit-phonebook` and `body-limit-phonebook` exist before deploy; update any monitors referencing `rate-limit`. No traffic shift in this PR.

<sup>Written for commit cc0068050d3365f6d71fffee47da88c15d6da700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Alexbeav/devops-phonebook-demo/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

