### PR TITLE
security: use Cloudflare client identity for Phonebook

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -74,6 +74,7 @@ jobs:
 
           test "$entrypoints" = "websecure,websecure-cf"
           echo "$middlewares" | grep -Eq '(^|,)body-limit-phonebook(,|$)'
+          echo "$middlewares" | grep -Eq '(^|,)crowdsec-bouncer-cloudflare(,|$)'
           echo "$middlewares" | grep -Eq '(^|,)rate-limit-phonebook(,|$)'
 
   build-and-scan:

--- a/charts/myapp/values-prod.yaml
+++ b/charts/myapp/values-prod.yaml
@@ -13,7 +13,7 @@ ingress:
   tls:
     enabled: true
   middlewares:
-    - name: crowdsec-bouncer
+    - name: crowdsec-bouncer-cloudflare
       namespace: traefik
     - name: rate-limit-phonebook
       namespace: traefik


### PR DESCRIPTION
Switches public Phonebook to the Cloudflare-specific CrowdSec middleware keyed by CF-Connecting-IP and adds a CI assertion that prevents regression.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches public Phonebook to the Cloudflare-aware CrowdSec middleware so client identity comes from CF-Connecting-IP. Previously we used the generic bouncer keyed by the edge IP; now `crowdsec-bouncer-cloudflare` uses the real client IP behind Cloudflare. Adds a CI assertion to prevent regressions.

- Review and rollout
  - Helm values now reference `crowdsec-bouncer-cloudflare` in the `traefik` namespace; ensure this middleware is deployed.
  - CI checks for `crowdsec-bouncer-cloudflare` in the ingress middlewares; no app code changes.

<sup>Written for commit 6e81395c017db3ee9ae06e099110ed42fa33b37d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Alexbeav/devops-phonebook-demo/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

