### PR TITLE
security: enforce Phonebook content security policy

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -75,6 +75,7 @@ jobs:
           test "$entrypoints" = "websecure,websecure-cf"
           echo "$middlewares" | grep -Eq '(^|,)body-limit-phonebook(,|$)'
           echo "$middlewares" | grep -Eq '(^|,)crowdsec-bouncer-cloudflare(,|$)'
+          echo "$middlewares" | grep -Eq '(^|,)csp-phonebook(,|$)'
           echo "$middlewares" | grep -Eq '(^|,)rate-limit-phonebook(,|$)'
 
   build-and-scan:

--- a/charts/myapp/values-prod.yaml
+++ b/charts/myapp/values-prod.yaml
@@ -19,6 +19,8 @@ ingress:
       namespace: traefik
     - name: body-limit-phonebook
       namespace: traefik
+    - name: csp-phonebook
+      namespace: traefik
     - name: security-headers
       namespace: traefik
 # Public demo instance: application-enforced read-only mode plus a nightly


### PR DESCRIPTION
Attaches the Phonebook-specific restrictive Content Security Policy and adds a CI regression assertion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies a restrictive Content Security Policy to Phonebook and adds a CI assertion to prevent regressions. Previously Phonebook used generic security headers; now production ingress attaches the `csp-phonebook` Traefik middleware and CI verifies its presence.

**Review and rollout**
- Helm: add `csp-phonebook` to the Phonebook ingress in values for production.
- CI: workflow fails if `csp-phonebook` is missing from the Phonebook route middlewares.
- Required: ensure the `csp-phonebook` middleware resource exists in the `traefik` namespace before rollout.
- Risk: the stricter CSP may block inline or third‑party assets; test key views and update the policy if needed.

<sup>Written for commit 80c56a9610d5ec613dba1032b28f7f9b5a5cddc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Alexbeav/devops-phonebook-demo/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

